### PR TITLE
Put the spinner element in the table inside proper table elements

### DIFF
--- a/assets/src/modules/signup/Home.tsx
+++ b/assets/src/modules/signup/Home.tsx
@@ -99,7 +99,15 @@ export default class Home extends Component<HomeProps, HomeState> {
             </tr>
           </thead>
           <tbody>
-            {this.state.isLoading ? <Spinner animation="border" className="center-spinner" /> : this.renderGoalsList(this.state.goals)}
+              {
+                this.state.isLoading ?
+                (
+                  <tr><td>
+                    <Spinner animation="border" className="center-spinner" />
+                  </td></tr>
+                ) :
+                this.renderGoalsList(this.state.goals)
+            }
           </tbody>
         </Table>
       </div>


### PR DESCRIPTION
Put the spinner element in the table inside proper table elements. No longer logs a big ugly error about a div being a direct child element of tbody.

*Issue #, if available:*
no issue, minor bug only effecting logging.

*Description of changes:*
Just put the Spinner element inside tr td elements which cleans up the js console considerably when rendering the loading table.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
