### PR TITLE
Upgrade deprecated runtime nodejs8.10

### DIFF
--- a/extensions/cw-slack-chime/master.yaml
+++ b/extensions/cw-slack-chime/master.yaml
@@ -40,7 +40,7 @@ Resources:
         - ''
         - - !If [IsSlack, 'slack', 'chime']
           - '.handler'
-      Runtime: nodejs8.10
+      Runtime: nodejs10.x
       Role: !GetAtt 
         - WebhookRole
         - Arn
@@ -129,7 +129,7 @@ Resources:
       FunctionName: !Sub '${CloudwatchAlarm}-FunctionSetupAlert'
       Description: Setup subscription to alarm with SNS and trigger Send to Alert Lambda function. 
       Handler: index.handler
-      Runtime: nodejs8.10
+      Runtime: nodejs10.x
       Role: !GetAtt 
         - SetupAlertRole
         - Arn

--- a/extensions/search-api/master.yaml
+++ b/extensions/search-api/master.yaml
@@ -49,7 +49,7 @@ Resources:
       FunctionName: !Sub '${DynamoDBTable}-EnableStreams'
       Description: Enable streams for DynamoDB table
       Handler: index.handler
-      Runtime: nodejs8.10
+      Runtime: nodejs10.x
       Role: !GetAtt 
         - DynamoDBRole
         - Arn
@@ -143,7 +143,7 @@ Resources:
         'Fn::GetAtt':
           - RoleForCreateESRoleFunction
           - Arn
-      Runtime: nodejs8.10
+      Runtime: nodejs10.x
       Timeout: 300
     Type: 'AWS::Lambda::Function'
   ESRoleCreator:
@@ -438,7 +438,7 @@ Resources:
       FunctionName: !Sub '${DynamoDBTable}-APIGatewayInfo'
       Description: Retrieve info about API Gateway resource
       Handler: index.handler
-      Runtime: nodejs8.10
+      Runtime: nodejs10.x
       Role: !GetAtt 
         - GetAPIGatewayInfoRole
         - Arn


### PR DESCRIPTION
CloudFormation templates in aws-full-stack-template have been found to include a [deprecated Lambda function runtime](https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html) (nodejs8.10). The affected templates have been updated to a supported runtime (nodejs10.x).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.